### PR TITLE
Casting indexLast to bigint

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function fromMssql(conn, queryStr, batchSize) {
             select 'a' as rField, * from(${queryStr}) t
           ) tt
         ) ttt
-        where ttt.rIndex > ${indexLast}`;
+        where ttt.rIndex > CAST(${indexLast} AS BIGINT)`;
 
       var command = new tedious.Request(query, err => {
         // is last batch the final batch


### PR DESCRIPTION
ROW_NUMBER returns a bigint. When comparing to an integer I have found that SQL Server will sometime convert the bigint to an int on every row in the result. For larger tables this can slow the query down substantially. By converting indexLast to a bigint SQL Server does not have to convert anything.
